### PR TITLE
Fix link for "dev container features" in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dev Container Features: Self Authoring Template
 
-> This repo provides a starting point and example for creating your own custom [dev container features](), hosted for free on GitHub Container Registry.  The example in this repository follows the [**proposed**  dev container feature distribution specification](https://containers.dev/implementors/features-distribution/).  
+> This repo provides a starting point and example for creating your own custom [dev container features](https://containers.dev/implementors/features/), hosted for free on GitHub Container Registry.  The example in this repository follows the [**proposed**  dev container feature distribution specification](https://containers.dev/implementors/features-distribution/).  
 >
 > The proposed specification is in its _finalization_ phase and is subject to change.  To provide feedback to the specification, please leave a comment [on spec issue #70](https://github.com/devcontainers/spec/issues/70).  For more broad feedback regarding dev container features, please see [spec issue #61](https://github.com/devcontainers/spec/issues/61).
 


### PR DESCRIPTION
Hi 👋. This PR is intended for a minor link-fix in the README. I am assuming the expected link is the same one as [devcontainers/action](https://github.com/devcontainers/action)'s README.

- https://github.com/devcontainers/action/blob/main/README.md?plain=1#L11